### PR TITLE
useClaimer: Claimer query missing id

### DIFF
--- a/app/src/queries/index.js
+++ b/app/src/queries/index.js
@@ -25,7 +25,9 @@ export const Claimer = gql`
       latestClaimPeriod
       addressVoid
       claims {
-        claimer
+        claimer {
+          id
+        }
         amount
         period {
           id


### PR DESCRIPTION
Seems that something changed on theGraph and we were querying like this 

```   
claimer(id: $id) {
      registeredForPeriod
      latestClaimPeriod
      addressVoid
      claims {
        claimer 
        amount
        period {
          id
        }
      }
    }
  }
```
We need the id on the claimer sublevel query

```
claimer(id: $id) {
      registeredForPeriod
      latestClaimPeriod
      addressVoid
      claims {
        claimer {
          id
        }
        amount
        period {
          id
        }
      }
    }
  }
```