### PR TITLE
Sponsor user: invalid timestamp

### DIFF
--- a/app/src/endpoints.js
+++ b/app/src/endpoints.js
@@ -11,6 +11,8 @@ export const BRIGHTID_SUBSCRIPTION_ENDPOINT = `${BRIGHT_ID_ENDPOINT_V5}/operatio
 
 export const BRIGHT_ID_APP_DEEPLINK = `brightid://link-verification/${NODE_URL}/${CONTEXT_ID}`
 
+export const UTC_API_ENDPOINT = `http://worldclockapi.com/api/json/utc/now`
+
 // The graph endpoints
 const GRAPH_API_BASE_HTTP_LOCAL = 'http://127.0.0.1:8000'
 const GRAPH_API_BASE_WS_LOCAL = 'ws://127.0.0.1:8001'


### PR DESCRIPTION
We were using the user system timestamp and in some cases the users had future time in their system clock and that was causing some issues with the brightId API.

Now we are using this api  http://worldclockapi.com/ ( let's see how it goes) and in any case we are doing a fallback in case that this fetch doesn't work so we should encourage people to have they system clock synced