### PR TITLE
Fix: Verification info fetch

### DIFF
--- a/app/src/hooks/useBrightIdVerification.js
+++ b/app/src/hooks/useBrightIdVerification.js
@@ -98,10 +98,6 @@ export function useBrightIdVerification(account) {
     }
 
     const fetchVerificationInfo = async () => {
-      if (sponsorshipInfo.availableSponsorships === 0) {
-        return
-      }
-
       const endpoint = `${BRIGHTID_VERIFICATION_ENDPOINT}/${CONTEXT_ID}/${account}?signed=eth&timestamp=seconds`
       try {
         const rawResponse = await fetch(endpoint, {


### PR DESCRIPTION
If we are out of sponsorships, we shouldn't stop fetching verification info for users.

They could already be verified, so we shouldn't prevent them from registering /claiming if this is the case.

