### PR TITLE
Add custom ethereum chains to wallets (EIP-3085)

### DIFF
--- a/app/src/components/Account/ScreenError.js
+++ b/app/src/components/Account/ScreenError.js
@@ -4,6 +4,7 @@ import { GU, Link, textStyle, useTheme } from '@1hive/1hive-ui'
 import { UnsupportedChainError } from 'use-wallet'
 import { getNetworkName } from '../../lib/web3-utils'
 import connectionError from './assets/connection-error.png'
+import { addEthereumChain } from '../../networks'
 
 function AccountModuleErrorScreen({ error, onBack }) {
   const theme = useTheme()
@@ -11,6 +12,7 @@ function AccountModuleErrorScreen({ error, onBack }) {
 
   const [title, secondary] = useMemo(() => {
     if (error instanceof UnsupportedChainError) {
+      addEthereumChain()
       return [
         'Wrong network',
         `Please select the ${getNetworkName()} network in your wallet and try again.`,

--- a/app/src/networks.js
+++ b/app/src/networks.js
@@ -25,6 +25,16 @@ const networks = {
     type: 'xdai',
     defaultEthNode: 'https://xdai.poanetwork.dev/',
     faucet: '0x967ebb4343c442d19a47b9196d121bd600600911',
+    eip3085: {
+      chainId: '0x64',
+      chainName: 'xDai',
+      rpcUrls: ['https://xdai.poanetwork.dev/'],
+      iconUrls: [
+        'https://gblobscdn.gitbook.com/spaces%2F-Lpi9AHj62wscNlQjI-l%2Favatar.png',
+      ],
+      nativeCurrency: { name: 'xDAI', symbol: 'xDAI', decimals: 18 },
+      blockExplorerUrls: ['https://blockscout.com/poa/xdai/'],
+    },
   },
 }
 
@@ -42,4 +52,12 @@ export function getAvailableNetworks() {
     name,
     type,
   }))
+}
+
+export function addEthereumChain() {
+  const { eip3085 } = getNetwork()
+  window.ethereum.request({
+    method: 'wallet_addEthereumChain',
+    params: [eip3085],
+  })
 }


### PR DESCRIPTION
It calls the `wallet_addEthereumChain` function so a popup to add the xdai chain appears when we are in any other network. Unfortunately it doesn't have support for "official" chains (mainnet, rinkeby...).

Please could you review if that's the best place to put the `window.ethereum` call? I think it's ok, but if you prefer, I can fork `use-wallet` in 1hive and call this function from it.